### PR TITLE
Update to match the current specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,31 +13,38 @@ A binding is done between the *BitcoinHdr.cmd* and the good *BitcoinMessage* (wh
 
 command     | class
 ------------|----------------------
-inv         | *BitcoinInv*
-header      | *BitcoinHeader*
-pong        | *BitcoinPong*
-checkorder  | *BitcoinCheckorder*
-filterload  | *BitcoinFilterload*
 addr        | *BitcoinAddr*
-tx          | *BitcoinTx*
+alert       | *BitcoinAlert*
+block       | *BitcoinBlock*
+blocktxn    | *BitcoinBlocktxn*
+checkorder  | *BitcoinCheckorder*
+cmpctblock  | *BitcoinCmpctblock*
+feefilter   | *BitcoinFeefilter*
 filteradd   | *BitcoinFilteradd*
-ping        | *BitcoinPing*
+filterclear | *BitcoinFilterclear*
+filterload  | *BitcoinFilterload*
+getaddr     | *BitcoinGetaddr*
+getblocks   | *BitcoinGetblocks*
+getblocktxn | *BitcoinGetblocktxn*
+getdata     | *BitcoinGetdata*
 getheaders  | *BitcoinGetheaders*
-version     | *BitcoinVersion*
+header      | *BitcoinHeader*
+inv         | *BitcoinInv*
+mempool     | *BitcoinMempool*
+merkleblock | *BitcoinMerkleblock*
+notfound    | *BitcoinNotfound*
+ping        | *BitcoinPing*
+pong        | *BitcoinPong*
 reject      | *BitcoinReject*
 reply       | *BitcoinReply*
+sendcmpct   | *BitcoinSendcmpct*
 submitorder | *BitcoinSubmitorder*
-alert       | *BitcoinAlert*
-getaddr     | *BitcoinGetaddr*
-mempool     | *BitcoinMempool*
-getdata     | *BitcoinGetdata*
-getblocks   | *BitcoinGetblocks*
-notfound    | *BitcoinNotfound*
+tx          | *BitcoinTx*
 verack      | *BitcoinVerack*
-filterclear | *BitcoinFilterclear*
-block       | *BitcoinBlock*
+version     | *BitcoinVersion*
 
-**Note** : checkorder, submitorder, reply are deprecated in the current protocol version.
+
+**Note** : checkorder, submitorder, reply and alert are deprecated in the current protocol version.
 
 ## Usage example
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bitcoin packets for Scapy
 Implementation of Bitcoin protocol messages in Scapy.
 
+**The script runs only under phyton 2.x**
+
 All Bitcoin messages are built as follwing :
 ```python
 BitcoinHdr() / BitcoinMessage()

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -786,6 +786,19 @@ class BitcoinFilterclear(BitcoinMessage):
     ]
 
 
+class BitcoinFeefilter(BitcoinMessage):
+    """
+    Added in protocol version 70013 as described by BIP133.
+
+    The feefilter message is a request to the receiving peer to not relay any transaction inv messages to the sending peer where the fee rate for the transaction is below the fee rate specified in the feefilter message.
+    """
+    cmd = "feefilter"
+
+    fields_desc = [
+        XLELongField("feerate", 0),
+    ]
+
+
 class BitcoinAlertPayload(Packet):
     """
     Support for alert messages has been removed from bitcoin core in March 2016.

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -123,7 +123,7 @@ class ChecksumField(XIntField):
     def i2m(self, pkt, x):
         if x is None:
             pay = str(getattr(pkt,"payload",""))
-            x = hashlib.sha256((hashlib.sha256(pay.encode('utf-8')).digest())).digest()
+            x = hashlib.sha256((hashlib.sha256(pay).digest())).digest()
             x = struct.unpack(self.fmt, x[0:4])[0]
 
         return x
@@ -198,15 +198,15 @@ class VarIntField(FieldLenField):
     -                   9            0xFF followed by the length as uint64_t
     """
 
-    def __init__(self, name, default, length_of=None, count_of=None):
-        FieldLenField.__init__(self, name, default, fmt="B",length_of=length_of,count_of=count_of)
+    def __init__(self, name, default, count_of=None):
+        FieldLenField.__init__(self, name, default, fmt="B", count_of=count_of)
 
     def i2m(self, pkt, x):
         if x is None:
-            if self.length_of is not None:
-                fld,fval = pkt.getfield_and_val(self.length_of)
-                f = fld.i2len(pkt, fval)
-            x = f
+            if self.count_of is not None:
+                x = len(getattr(pkt, self.count_of))
+            else:
+                x = 0
         return x
 
     def getfield(self, pkt, s):
@@ -259,7 +259,7 @@ class VarStrPktField(Packet):
     """
 
     fields_desc = [
-            VarIntField("len",None, length_of="data"),
+            VarIntField("len",None, count_of="data"),
             StrLenField("data","", length_from= lambda pkt : pkt.len),
         ]
 

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -459,9 +459,9 @@ class BitcoinVersion(BitcoinMessage):
         LEIntField("version",0),
         LELongEnumField("services",0, SERVICES_TYPES),
         LTimestampField("timestamp",int(time.time())),
+        PacketField("addr_recv", AddrWithoutTimePktField(), AddrWithoutTimePktField),
 
         # Fields below require version >= 106
-        ConditionalField(PacketField("addr_recv", AddrWithoutTimePktField(), AddrWithoutTimePktField), lambda pkt : pkt.version >= 106),
         ConditionalField(PacketField("addr_from", AddrWithoutTimePktField(), AddrWithoutTimePktField), lambda pkt : pkt.version >= 106),
         ConditionalField(LELongField("nonce", 0 ), lambda pkt : pkt.version >= 106),
         ConditionalField(PacketField("user_agent", VarStrPktField(), VarStrPktField), lambda pkt : pkt.version >= 106),

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -326,10 +326,9 @@ class BlockHeaderPktField(Packet):
         LEIntField("version",0),
         StrFixedLenField("prev_block", "", length=32),
         StrFixedLenField("merkle_root", "", length=32),
-        LTimestampField("timestamp",int(time.time())),
+        TimestampField("timestamp",int(time.time())),
         LEIntField("bits",0), # The calculated difficulty target being used for this block
-        LELongField("nonce", 0 ),
-        #VarIntField("txn_count",0),
+        LEIntField("nonce", 0)
     ]
 
     def extract_padding(self, s):

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -592,11 +592,11 @@ class BitcoinBlock(BitcoinMessage):
     ]
 
 
-class BitcoinHeader(BitcoinMessage):
+class BitcoinHeaders(BitcoinMessage):
     """
     The headers packet returns block headers in response to a getheaders packet.
     """
-    cmd = "header"
+    cmd = "headers"
 
     fields_desc = [
         VarIntField("count",None, count_of="headers"),

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -468,7 +468,7 @@ class BitcoinVersion(BitcoinMessage):
         ConditionalField(LEIntField("start_height",0), lambda pkt : pkt.version >= 106),
 
         # Fields below require version >= 70001
-        ConditionalField(ByteField("relay", 0), lambda pkt : pkt.version >=7001)
+        ConditionalField(ByteField("relay", 0), lambda pkt : pkt.version >= 70001)
     ]
 
 

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -741,49 +741,43 @@ class BitcoinReject(BitcoinMessage):
     ]
 
 
-# Flowing Bloom filter messages are describe here : https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
-
-
 class BitcoinFilterload(BitcoinMessage):
+    """
+    Added in protocol version 70001.
+
+    The filterload message tells the receiving peer to filter all relayed transactions and requested merkle blocks through the provided filter.
+    """
+
     cmd = "filterload"
 
     fields_desc = [
-        StrLenField(
-            "filter", "", length_from=lambda pkt: pkt.underlayer.len - 9
-        ),  # The maximum size is 36,000 bytes
-        XLEIntField(
-            "n_hash_functs", 0
-        ),  # The maximum value allowed in this field is 50
+        PacketField("filter", VarStrPktField(), VarStrPktField),
+        XLEIntField("n_hash_functs", 0),
         XLEIntField("n_tweak", 0),
         XByteField("n_flags", 0),
     ]
 
 
 class BitcoinFilteradd(BitcoinMessage):
+    """
+    Added in protocol version 70001.
+
+    The filteradd message tells the receiving peer to add a single element to a previously-set bloom filter, such as a new public key.
+    """
+
     cmd = "filteradd"
 
-    fields_desc = [StrLenField("filter", "")]
+    fields_desc = [PacketField("filter", VarStrPktField(), VarStrPktField)]
 
 
 class BitcoinFilterclear(BitcoinMessage):
-    cmd = "filterclear"
+    """
+    Added in protocol version 70001.
 
-    fields_desc = [
-        LEIntField("version", 0),
-        HashField("prev_block", 0),
-        HashField("merkel_block", 0),
-        TimestampField("timestamp", int(time.time())),
-        LEIntField(
-            "bits", 0
-        ),  # The calculated difficulty target being used for this block
-        XLEIntField("nonce", 0),
-        LEIntField("nb_transactions", 0),
-        VarIntField("len_hashes", None, count_of="hashes"),
-        FieldListField(
-            "hashes", [], HashField("hash", None), count_from=lambda pkt: pkt.len_hashes
-        ),
-        StrLenField("flags", ""),
-    ]
+    The filterclear message tells the receiving peer to remove a previously-set bloom filter. This also undoes the effect of setting the relay field in the version message to 0, allowing unfiltered access to inv messages announcing new transactions.
+    """
+
+    cmd = "filterclear"
 
 
 class BitcoinMerkleblock(BitcoinMessage):

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -36,10 +36,10 @@ import struct
 
 
 INVENTORY_TYPES = {
-                    0x0 : "ERROR",
-                    0x1 : "MSG_TX",
-                    0x2 : "MSG_BLOCK",
-                    0x3 : "MSG_FILTERED_BLOCK"
+    0x0: "ERROR",
+    0x1: "MSG_TX",
+    0x2: "MSG_BLOCK",
+    0x3: "MSG_FILTERED_BLOCK",
 }
 
 # Magic numbers that correspond to the network used
@@ -48,41 +48,44 @@ MAGIC_REGTEST = 0xDAB5BFFA
 MAGIC_TESTNET3 = 0x0709110B
 MAGIC_NAMECOIN = 0xFEB4BEF9
 MAGIC_VALUES = {
-                MAGIC_MAIN : "main",
-                MAGIC_REGTEST : "regtest",
-                MAGIC_TESTNET3 : "testnet3",
-                MAGIC_NAMECOIN : "namecoin",
+    MAGIC_MAIN: "main",
+    MAGIC_REGTEST: "regtest",
+    MAGIC_TESTNET3: "testnet3",
+    MAGIC_NAMECOIN: "namecoin",
 }
 
 # Port Binding Conf
-MAGIC_PORT_BINDING = {  MAGIC_MAIN : 8333,
-                        MAGIC_REGTEST : 18444,
-                        MAGIC_TESTNET3 : 18333,
-                        # MAGIC_NAMECOIN : ???? # TBD
+MAGIC_PORT_BINDING = {
+    MAGIC_MAIN: 8333,
+    MAGIC_REGTEST: 18444,
+    MAGIC_TESTNET3: 18333,
+    # MAGIC_NAMECOIN : ???? # TBD
 }
 
-SERVICES_TYPES = { 0x1 : "NODE_NETWORK" }
+SERVICES_TYPES = {0x1: "NODE_NETWORK"}
 
 
 REJECT_CCODES = {
-        0x01 : "REJECT_MALFORMED",
-        0x10 : "REJECT_INVALID",
-        0x11 : "REJECT_OBSOLETE",
-        0x12 : "REJECT_DUPLICATE",
-        0x40 : "REJECT_NONSTANDARD",
-        0x41 : "REJECT_DUST",
-        0x42 : "REJECT_INSUFFICIENTFEE",
-        0x43 : "REJECT_CHECKPOINT",
+    0x01: "REJECT_MALFORMED",
+    0x10: "REJECT_INVALID",
+    0x11: "REJECT_OBSOLETE",
+    0x12: "REJECT_DUPLICATE",
+    0x40: "REJECT_NONSTANDARD",
+    0x41: "REJECT_DUST",
+    0x42: "REJECT_INSUFFICIENTFEE",
+    0x43: "REJECT_CHECKPOINT",
 }
 
 
 # Used to display timestamp
 def timestamp_to_str(ts):
-    return datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+
 
 ###########################
 # BiteCoin Fields
 ###########################
+
 
 class XLEIntField(LEIntField):
     def i2repr(self, pkt, x):
@@ -98,8 +101,10 @@ class XStrFixedLenField(StrFixedLenField):
     """
     Hexadecimal representation of a StrFixedLenField
     """
+
     def i2repr(self, pkt, x):
         return binascii.hexlify(x)
+
 
 class LELongEnumField(EnumField):
     def __init__(self, name, default, enum):
@@ -107,7 +112,6 @@ class LELongEnumField(EnumField):
 
 
 class HashField(XStrFixedLenField):
-
     def __init__(self, name, default):
         XStrFixedLenField.__init__(self, name, default, length=32)
 
@@ -122,16 +126,18 @@ class ChecksumField(XIntField):
 
     def i2m(self, pkt, x):
         if x is None:
-            pay = str(getattr(pkt,"payload",""))
+            pay = str(getattr(pkt, "payload", ""))
             x = hashlib.sha256((hashlib.sha256(pay).digest())).digest()
             x = struct.unpack(self.fmt, x[0:4])[0]
 
         return x
 
+
 class LTimestampField(LELongField):
     """
     Long timestamp
     """
+
     def __init__(self, name, default):
         LELongField.__init__(self, name, default)
 
@@ -151,6 +157,7 @@ class TimestampField(LEIntField):
     """
     Int timestamp
     """
+
     def __init__(self, name, default):
         LEIntField.__init__(self, name, default)
 
@@ -165,6 +172,7 @@ class TimestampField(LEIntField):
         else:
             return timestamp_to_str(x)
 
+
 class LockTimeField(LEIntField):
     """
     The block number or timestamp at which this transaction is locked:
@@ -177,13 +185,14 @@ class LockTimeField(LEIntField):
     def i2h(self, pkt, x):
         if x == 0:
             pass
-        if x < 500000000: # Block Number
+        if x < 500000000:  # Block Number
             return hex(x)
-        else: # Timestamp
+        else:  # Timestamp
             if x is None:
                 return None
             else:
                 return timestamp_to_str(x)
+
 
 class VarIntField(FieldLenField):
     """
@@ -213,19 +222,19 @@ class VarIntField(FieldLenField):
         """Extract an internal value from a string"""
 
         self.sz = 1
-        self.fmt="B"
+        self.fmt = "B"
 
         offset = 0
         val = struct.unpack(self.fmt, s[:1])
         val = val[0]
 
         if val == 0xFD:
-            self.sz=2
+            self.sz = 2
             self.fmt = ">H"
             offset = 1
 
         elif val == 0xFE:
-            self.sz=4
+            self.sz = 4
             self.fmt = ">I"
             offset = 1
 
@@ -234,21 +243,24 @@ class VarIntField(FieldLenField):
             self.fmt = ">L"
             offset = 1
 
-        return s[offset+self.sz:], self.m2i(pkt, struct.unpack(self.fmt, s[offset:offset+self.sz])[0])
+        return (
+            s[offset + self.sz :],
+            self.m2i(pkt, struct.unpack(self.fmt, s[offset : offset + self.sz])[0]),
+        )
 
     def addfield(self, pkt, s, val):
         """Add an internal value  to a string"""
 
-        val = self.i2m(pkt,val)
+        val = self.i2m(pkt, val)
 
-        if val < 0xfd:
-            f_s = struct.pack("B",val)
-        elif val <= 0xffff:
-            f_s = "\xfd" + struct.pack(">H",val)
-        elif val <= 0xffffffff:
-            f_s = "\xfe" + struct.pack(">I",val)
+        if val < 0xFD:
+            f_s = struct.pack("B", val)
+        elif val <= 0xFFFF:
+            f_s = "\xfd" + struct.pack(">H", val)
+        elif val <= 0xFFFFFFFF:
+            f_s = "\xfe" + struct.pack(">I", val)
         else:
-            f_s = "\xff" + struct.pack(">L",val)
+            f_s = "\xff" + struct.pack(">L", val)
 
         return s + f_s
 
@@ -259,12 +271,12 @@ class VarStrPktField(Packet):
     """
 
     fields_desc = [
-            VarIntField("len",None, count_of="data"),
-            StrLenField("data","", length_from= lambda pkt : pkt.len),
-        ]
+        VarIntField("len", None, count_of="data"),
+        StrLenField("data", "", length_from=lambda pkt: pkt.len),
+    ]
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
 
 
 class AddrPktField(Packet):
@@ -274,14 +286,15 @@ class AddrPktField(Packet):
     """
 
     fields_desc = [
-        TimestampField("time",int(time.time())),
+        TimestampField("time", int(time.time())),
         LELongEnumField("services", 0, SERVICES_TYPES),
         IP6Field("addr", "fc00:1::1"),
         ShortField("port", 8333),
     ]
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
+
 
 class AddrWithoutTimePktField(Packet):
     """
@@ -303,19 +316,22 @@ class AddrWithoutTimePktField(Packet):
         return Packet.build(self)
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
+
 
 class InventoryPktField(Packet):
     """
     Inventory vectors are used for notifying other nodes about objects they have or data which is being requested.
     """
+
     fields_desc = [
-        LEIntEnumField("type",0, INVENTORY_TYPES),
-        HashField("hash",None),
+        LEIntEnumField("type", 0, INVENTORY_TYPES),
+        HashField("hash", None),
     ]
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
+
 
 class BlockHeaderPktField(Packet):
     """
@@ -323,25 +339,29 @@ class BlockHeaderPktField(Packet):
     """
 
     fields_desc = [
-        LEIntField("version",0),
+        LEIntField("version", 0),
         StrFixedLenField("prev_block", "", length=32),
         StrFixedLenField("merkle_root", "", length=32),
-        TimestampField("timestamp",int(time.time())),
-        LEIntField("bits",0), # The calculated difficulty target being used for this block
-        LEIntField("nonce", 0)
+        TimestampField("timestamp", int(time.time())),
+        LEIntField(
+            "bits", 0
+        ),  # The calculated difficulty target being used for this block
+        LEIntField("nonce", 0),
     ]
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
+
 
 class OutPointPktField(Packet):
     fields_desc = [
-        HashField("hash",None),
-        LEIntField("index",0),
+        HashField("hash", None),
+        LEIntField("index", 0),
     ]
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
+
 
 class TxInPktField(Packet):
     """
@@ -352,13 +372,14 @@ class TxInPktField(Packet):
 
     fields_desc = [
         OutPointPktField,
-        VarIntField("script_len",None, count_of="sign_script"),
-        StrLenField("sign_script","", length_from=lambda pkt: pkt.script_len),
+        VarIntField("script_len", None, count_of="sign_script"),
+        StrLenField("sign_script", "", length_from=lambda pkt: pkt.script_len),
         XLEIntField("sequence", 0),
     ]
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
+
 
 class TxOutPktField(Packet):
     """
@@ -367,12 +388,13 @@ class TxOutPktField(Packet):
 
     fields_desc = [
         LELongField("value", 0),
-        VarIntField("pk_script_len",None, count_of="pk_script"),
-        StrLenField("pk_script","", length_from=lambda pkt: pkt.pk_script_len),
+        VarIntField("pk_script_len", None, count_of="pk_script"),
+        StrLenField("pk_script", "", length_from=lambda pkt: pkt.pk_script_len),
     ]
 
     def extract_padding(self, s):
-        return "",s
+        return "", s
+
 
 #########################
 # Bitcoin Packets
@@ -383,13 +405,14 @@ class BitcoinHdr(Packet):
     """
     Common header
     """
+
     name = "Bitcoin Header"
 
     fields_desc = [
-         LEIntEnumField("magic", MAGIC_MAIN, MAGIC_VALUES),
-         StrFixedLenField("cmd","", 12),
-         LEIntField("len",None),
-         ChecksumField("checksum", None)
+        LEIntEnumField("magic", MAGIC_MAIN, MAGIC_VALUES),
+        StrFixedLenField("cmd", "", 12),
+        LEIntField("len", None),
+        ChecksumField("checksum", None),
     ]
 
     def build(self):
@@ -401,7 +424,7 @@ class BitcoinHdr(Packet):
 
     def guess_payload_class(self, payload):
         fld, val = self.getfield_and_val("cmd")
-        cmd = val.replace("\x00","")
+        cmd = val.replace("\x00", "")
         if cmd in BitcoinMessage.registered_message:
             return BitcoinMessage.registered_message[cmd]
         else:
@@ -424,8 +447,8 @@ class BitcoinHdrs(Packet):
         """
         Here a hack to return a BitcoinHdr class if there is only one Bitcoin packet in the TCP payload.
         """
-        if pkt is not None and ("_internal" not in kargs or (kargs["_internal"]==1)):
-            p = BitcoinHdrs(pkt,_internal=2) # Parse with BitcoinHdrs a first time
+        if pkt is not None and ("_internal" not in kargs or (kargs["_internal"] == 1)):
+            p = BitcoinHdrs(pkt, _internal=2)  # Parse with BitcoinHdrs a first time
             if len(p.messages) <= 1:
                 return BitcoinHdr
         return cls
@@ -435,6 +458,7 @@ class BitcoinMessage(Packet):
     """
     Abstract Bitcoin payload
     """
+
     cmd = None
     registered_message = {}
 
@@ -443,31 +467,37 @@ class BitcoinMessage(Packet):
         cmd = cls.cmd
         if cmd:
             cls.registered_message[cmd] = cls
-            if len(cmd) < 12: # Add \x00 padding
-                cmd = cmd + "\x00"*(12-len(cmd))
+            if len(cmd) < 12:  # Add \x00 padding
+                cmd = cmd + "\x00" * (12 - len(cmd))
             bind_layers(BitcoinHdr, cls, {"cmd": cmd})
 
     def extract_padding(self, pay):
-        return "",pay
+        return "", pay
 
 
 class BitcoinVersion(BitcoinMessage):
     cmd = "version"
 
     fields_desc = [
-        LEIntField("version",0),
-        LELongEnumField("services",0, SERVICES_TYPES),
-        LTimestampField("timestamp",int(time.time())),
+        LEIntField("version", 0),
+        LELongEnumField("services", 0, SERVICES_TYPES),
+        LTimestampField("timestamp", int(time.time())),
         PacketField("addr_recv", AddrWithoutTimePktField(), AddrWithoutTimePktField),
-
         # Fields below require version >= 106
-        ConditionalField(PacketField("addr_from", AddrWithoutTimePktField(), AddrWithoutTimePktField), lambda pkt : pkt.version >= 106),
-        ConditionalField(LELongField("nonce", 0 ), lambda pkt : pkt.version >= 106),
-        ConditionalField(PacketField("user_agent", VarStrPktField(), VarStrPktField), lambda pkt : pkt.version >= 106),
-        ConditionalField(LEIntField("start_height",0), lambda pkt : pkt.version >= 106),
-
+        ConditionalField(
+            PacketField(
+                "addr_from", AddrWithoutTimePktField(), AddrWithoutTimePktField
+            ),
+            lambda pkt: pkt.version >= 106,
+        ),
+        ConditionalField(LELongField("nonce", 0), lambda pkt: pkt.version >= 106),
+        ConditionalField(
+            PacketField("user_agent", VarStrPktField(), VarStrPktField),
+            lambda pkt: pkt.version >= 106,
+        ),
+        ConditionalField(LEIntField("start_height", 0), lambda pkt: pkt.version >= 106),
         # Fields below require version >= 70001
-        ConditionalField(ByteField("relay", 0), lambda pkt : pkt.version >= 70001)
+        ConditionalField(ByteField("relay", 0), lambda pkt: pkt.version >= 70001),
     ]
 
 
@@ -475,6 +505,7 @@ class BitcoinVerack(BitcoinMessage):
     """
     The verack message is sent in reply to version. This message consists of only a message header with the cmd string "verack".
     """
+
     cmd = "verack"
 
 
@@ -482,11 +513,14 @@ class BitcoinAddr(BitcoinMessage):
     """
     Provide information on known nodes of the network. Non-advertised nodes should be forgotten after typically 3 hours
     """
+
     cmd = "addr"
 
     fields_desc = [
-        VarIntField("count",None, count_of="addr_list"),
-        PacketListField("addr_list", [], AddrPktField, count_from=lambda pkt: pkt.count),
+        VarIntField("count", None, count_of="addr_list"),
+        PacketListField(
+            "addr_list", [], AddrPktField, count_from=lambda pkt: pkt.count
+        ),
     ]
 
 
@@ -494,11 +528,14 @@ class BitcoinInv(BitcoinMessage):
     """
     Allows a node to advertise its knowledge of one or more objects. It can be received unsolicited, or in reply to getblocks.
     """
+
     cmd = "inv"
 
     fields_desc = [
-        VarIntField("count",None, count_of="inventory"),
-        PacketListField("inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count),
+        VarIntField("count", None, count_of="inventory"),
+        PacketListField(
+            "inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count
+        ),
     ]
 
 
@@ -506,11 +543,14 @@ class BitcoinGetdata(BitcoinMessage):
     """
     getdata is used in response to inv
     """
+
     cmd = "getdata"
 
     fields_desc = [
-        VarIntField("count",None, count_of="inventory"),
-        PacketListField("inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count),
+        VarIntField("count", None, count_of="inventory"),
+        PacketListField(
+            "inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count
+        ),
     ]
 
 
@@ -519,40 +559,49 @@ class BitcoinNotfound(BitcoinMessage):
     notfound is a response to a getdata, sent if any requested data items could not be relayed,
     for example, because the requested transaction was not in the memory pool or relay se
     """
+
     cmd = "notfound"
 
     fields_desc = [
-        VarIntField("count",None, count_of="inventory"),
-        PacketListField("inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count),
+        VarIntField("count", None, count_of="inventory"),
+        PacketListField(
+            "inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count
+        ),
     ]
 
 
 class BitcoinGetblocks(BitcoinMessage):
-   """
+    """
    Return an inv packet containing the list of blocks starting right after the last
    known hash in the block locator object, up to hash_stop or 500 blocks, whichever comes first.
    """
-   cmd = "getblocks"
 
-   fields_desc = [
-        LEIntField("version",0),
-        VarIntField("hash_count",None, count_of="hashes"),
-        FieldListField("hashes", [], HashField("",0), count_from=lambda pkt : pkt.hash_count),
+    cmd = "getblocks"
+
+    fields_desc = [
+        LEIntField("version", 0),
+        VarIntField("hash_count", None, count_of="hashes"),
+        FieldListField(
+            "hashes", [], HashField("", 0), count_from=lambda pkt: pkt.hash_count
+        ),
         HashField("hash_stop", None),
     ]
 
 
 class BitcoinGetheaders(BitcoinMessage):
-   """
+    """
     Return a headers packet containing the headers of blocks starting right after the last
     known hash in the block locator object, up to hash_stop or 2000 blocks, whichever comes first
    """
-   cmd = "getheaders"
 
-   fields_desc = [
-        LEIntField("version",0),
-        VarIntField("hash_count",None, count_of="hashes"),
-        FieldListField("hashes", [], HashField("",None), count_from=lambda pkt : pkt.hash_count),
+    cmd = "getheaders"
+
+    fields_desc = [
+        LEIntField("version", 0),
+        VarIntField("hash_count", None, count_of="hashes"),
+        FieldListField(
+            "hashes", [], HashField("", None), count_from=lambda pkt: pkt.hash_count
+        ),
         HashField("hash_stop", None),
     ]
 
@@ -561,14 +610,19 @@ class BitcoinTx(BitcoinMessage):
     """
     tx describes a bitcoin transaction, in reply to getdata
     """
+
     cmd = "tx"
 
     fields_desc = [
-        LEIntField("version",0),
-        VarIntField("tx_in_count",None, count_of="tx_in"),
-        PacketListField("tx_in", [], TxInPktField, count_from=lambda pkt : pkt.tx_in_count), # TODO
-        VarIntField("tx_out_count",None, count_of="tx_out"),
-        PacketListField("tx_out", [], TxOutPktField, count_from=lambda pkt : pkt.tx_out_count), # TODO
+        LEIntField("version", 0),
+        VarIntField("tx_in_count", None, count_of="tx_in"),
+        PacketListField(
+            "tx_in", [], TxInPktField, count_from=lambda pkt: pkt.tx_in_count
+        ),  # TODO
+        VarIntField("tx_out_count", None, count_of="tx_out"),
+        PacketListField(
+            "tx_out", [], TxOutPktField, count_from=lambda pkt: pkt.tx_out_count
+        ),  # TODO
         LockTimeField("lock_time", None),
     ]
 
@@ -577,16 +631,19 @@ class BitcoinBlock(BitcoinMessage):
     """
     The block message is sent in response to a getdata message which requests transaction information from a block hash.
     """
+
     cmd = "block"
 
     fields_desc = [
-        LEIntField("version",0),
-        HashField("prev_block",0),
-        HashField("merkel_block",0),
+        LEIntField("version", 0),
+        HashField("prev_block", 0),
+        HashField("merkel_block", 0),
         TimestampField("timestamp", int(time.time())),
-        LEIntField("bits",0), # The calculated difficulty target being used for this block
-        XLEIntField("nonce",0),
-        VarIntField("txn_count",None, count_of="txns"),
+        LEIntField(
+            "bits", 0
+        ),  # The calculated difficulty target being used for this block
+        XLEIntField("nonce", 0),
+        VarIntField("txn_count", None, count_of="txns"),
         PacketListField("txns", [], BitcoinTx),
     ]
 
@@ -595,11 +652,12 @@ class BitcoinHeaders(BitcoinMessage):
     """
     The headers packet returns block headers in response to a getheaders packet.
     """
+
     cmd = "headers"
 
     fields_desc = [
-        VarIntField("count",None, count_of="headers"),
-        PacketListField("headers", [], BlockHeaderPktField)
+        VarIntField("count", None, count_of="headers"),
+        PacketListField("headers", [], BlockHeaderPktField),
     ]
 
 
@@ -608,6 +666,7 @@ class BitcoinGetaddr(BitcoinMessage):
     The getaddr message sends a request to a node asking for information about known active peers to
     help with finding potential nodes in the network.
     """
+
     cmd = "getaddr"
 
 
@@ -615,6 +674,7 @@ class BitcoinMempool(BitcoinMessage):
     """
     The mempool message sends a request to a node asking for information about transactions it has verified but which have not yet confirmed.
     """
+
     cmd = "mempool"
 
 
@@ -622,6 +682,7 @@ class BitcoinCheckorder(BitcoinMessage):
     """
     This message was used for IP Transactions. As IP transactions have been deprecated, it is no longer used.
     """
+
     cmd = "checkorder"
 
 
@@ -629,6 +690,7 @@ class BitcoinSubmitorder(BitcoinMessage):
     """
     This message was used for IP Transactions. As IP transactions have been deprecated, it is no longer used.
     """
+
     cmd = "submitorder"
 
 
@@ -636,6 +698,7 @@ class BitcoinReply(BitcoinMessage):
     """
     This message was used for IP Transactions. As IP transactions have been deprecated, it is no longer used.
     """
+
     cmd = "reply"
 
 
@@ -643,10 +706,11 @@ class BitcoinPing(BitcoinMessage):
     """
     The ping message is sent primarily to confirm that the TCP/IP connection is still valid.
     """
+
     cmd = "ping"
 
     fields_desc = [
-        XLELongField("nonce",0),
+        XLELongField("nonce", 0),
     ]
 
 
@@ -655,10 +719,11 @@ class BitcoinPong(BitcoinMessage):
     The pong message is sent in response to a ping message.
     In modern protocol versions, a pong response is generated using a nonce included in the ping.
     """
+
     cmd = "pong"
 
     fields_desc = [
-        XLELongField("nonce",0),
+        XLELongField("nonce", 0),
     ]
 
 
@@ -667,21 +732,28 @@ class BitcoinReject(BitcoinMessage):
     cmd = "reject"
 
     fields_desc = [
-                   PacketField("message", VarStrPktField(), VarStrPktField),
-                   ByteEnumField("ccode",0, REJECT_CCODES),
-                   PacketField("reason", VarStrPktField(), VarStrPktField), # Text version of the reason
-                   StrField("data",""),
+        PacketField("message", VarStrPktField(), VarStrPktField),
+        ByteEnumField("ccode", 0, REJECT_CCODES),
+        PacketField(
+            "reason", VarStrPktField(), VarStrPktField
+        ),  # Text version of the reason
+        StrField("data", ""),
     ]
 
 
 # Flowing Bloom filter messages are describe here : https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
 
+
 class BitcoinFilterload(BitcoinMessage):
     cmd = "filterload"
 
     fields_desc = [
-        StrLenField("filter", "", length_from=lambda pkt: pkt.underlayer.len - 9), # The maximum size is 36,000 bytes
-        XLEIntField("n_hash_functs", 0), # The maximum value allowed in this field is 50
+        StrLenField(
+            "filter", "", length_from=lambda pkt: pkt.underlayer.len - 9
+        ),  # The maximum size is 36,000 bytes
+        XLEIntField(
+            "n_hash_functs", 0
+        ),  # The maximum value allowed in this field is 50
         XLEIntField("n_tweak", 0),
         XByteField("n_flags", 0),
     ]
@@ -690,59 +762,75 @@ class BitcoinFilterload(BitcoinMessage):
 class BitcoinFilteradd(BitcoinMessage):
     cmd = "filteradd"
 
-    fields_desc = [
-        StrLenField("filter", "")
-    ]
+    fields_desc = [StrLenField("filter", "")]
 
 
 class BitcoinFilterclear(BitcoinMessage):
     cmd = "filterclear"
 
     fields_desc = [
-        LEIntField("version",0),
-        HashField("prev_block",0),
-        HashField("merkel_block",0),
+        LEIntField("version", 0),
+        HashField("prev_block", 0),
+        HashField("merkel_block", 0),
         TimestampField("timestamp", int(time.time())),
-        LEIntField("bits",0), # The calculated difficulty target being used for this block
-        XLEIntField("nonce",0),
-        LEIntField("nb_transactions",0),
-        VarIntField("len_hashes",None, count_of="hashes"),
-        FieldListField("hashes", [], HashField("hash", None), count_from=lambda pkt : pkt.len_hashes),
+        LEIntField(
+            "bits", 0
+        ),  # The calculated difficulty target being used for this block
+        XLEIntField("nonce", 0),
+        LEIntField("nb_transactions", 0),
+        VarIntField("len_hashes", None, count_of="hashes"),
+        FieldListField(
+            "hashes", [], HashField("hash", None), count_from=lambda pkt: pkt.len_hashes
+        ),
         StrLenField("flags", ""),
     ]
 
 
 class BitcoinAlertPayload(Packet):
+    """
+    Support for alert messages has been removed from bitcoin core in March 2016.
+    """
 
     fields_desc = [
-        LEIntField("version",0),
+        LEIntField("version", 0),
         LTimestampField("relay_until", int(time.time())),
         LTimestampField("expiration", int(time.time())),
-        XIntField("alert_id",0),
-        XIntField("cancel",0),
-        VarIntField("len_set_cancel",None, count_of="set_cancel"),
-        FieldListField("set_cancel", [], LEIntField("",0), count_from=lambda pkt: pkt.len_set_cancel),
-        IntField("min_ver",0),
-        IntField("max_ver",0),
-        VarIntField("len_set_sub_ver",None, count_of="set_sub_ver"),
-        FieldListField("set_sub_ver", [], VarStrPktField("",0), count_from=lambda pkt: pkt.len_set_sub_ver),
-        LEIntField("priority",0),
+        XIntField("alert_id", 0),
+        XIntField("cancel", 0),
+        VarIntField("len_set_cancel", None, count_of="set_cancel"),
+        FieldListField(
+            "set_cancel",
+            [],
+            LEIntField("", 0),
+            count_from=lambda pkt: pkt.len_set_cancel,
+        ),
+        IntField("min_ver", 0),
+        IntField("max_ver", 0),
+        VarIntField("len_set_sub_ver", None, count_of="set_sub_ver"),
+        FieldListField(
+            "set_sub_ver",
+            [],
+            VarStrPktField("", 0),
+            count_from=lambda pkt: pkt.len_set_sub_ver,
+        ),
+        LEIntField("priority", 0),
         PacketField("comment", VarStrPktField(), VarStrPktField),
         PacketField("status_bar", VarStrPktField(), VarStrPktField),
         PacketField("reserved", VarStrPktField(), VarStrPktField),
     ]
 
+
 class BitcoinAlert(BitcoinMessage):
     """
+    Support for alert messages has been removed from bitcoin core in March 2016.
+
     Alert messages are signed by developpers of Satoshi's client.
     Signature is an ECDSA of the BitcoinAlertPayload
     """
+
     cmd = "alert"
 
-    fields_desc = [
-        BitcoinAlertPayload,
-        StrField("signature", "")
-    ]
+    fields_desc = [BitcoinAlertPayload, StrField("signature", "")]
 
 
 for port in MAGIC_PORT_BINDING.values():

--- a/bitcoin.py
+++ b/bitcoin.py
@@ -498,8 +498,8 @@ class BitcoinInv(BitcoinMessage):
     cmd = "inv"
 
     fields_desc = [
-        VarIntField("count",None, count_of="inventroy"),
-        PacketListField("inventroy", [], InventoryPktField, count_from=lambda pkt: pkt.count),
+        VarIntField("count",None, count_of="inventory"),
+        PacketListField("inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count),
     ]
 
 
@@ -510,8 +510,8 @@ class BitcoinGetdata(BitcoinMessage):
     cmd = "getdata"
 
     fields_desc = [
-        VarIntField("count",None, count_of="inventroy"),
-        PacketListField("inventroy", [], InventoryPktField, count_from=lambda pkt: pkt.count),
+        VarIntField("count",None, count_of="inventory"),
+        PacketListField("inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count),
     ]
 
 
@@ -523,8 +523,8 @@ class BitcoinNotfound(BitcoinMessage):
     cmd = "notfound"
 
     fields_desc = [
-        VarIntField("count",None, count_of="inventroy"),
-        PacketListField("inventroy", [], InventoryPktField, count_from=lambda pkt: pkt.count),
+        VarIntField("count",None, count_of="inventory"),
+        PacketListField("inventory", [], InventoryPktField, count_from=lambda pkt: pkt.count),
     ]
 
 

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+from bitcoin import *
+
+
+#################################################################################
+# A demo script which genearates basic sameple binary packages for each message #
+#################################################################################
+if __name__ == "__main__":
+
+    # version
+    pkt = BitcoinHdr() / BitcoinVersion(
+        version=70001, user_agent=VarStrPktField(data="User_Agent"),
+    )
+    with open("samples/version.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # addr
+    pkt = BitcoinHdr() / BitcoinAddr(
+        count=2, addr_list=[AddrPktField(), AddrPktField()]
+    )
+    with open("samples/addr.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # inv
+    pkt = BitcoinHdr() / BitcoinInv(
+        inventory=[
+            InventoryPktField(hash="randomHash"),
+            InventoryPktField(hash="HashRandom"),
+            InventoryPktField(hash="nothinghash"),
+        ]
+    )
+    with open("samples/inv.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # getdata
+    pkt = BitcoinHdr() / BitcoinGetdata(
+        inventory=[InventoryPktField(hash="DataRandomHash"),]
+    )
+    with open("samples/getdata.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # notfound
+    pkt = BitcoinHdr() / BitcoinNotfound(
+        inventory=[
+            InventoryPktField(hash="NotfoundRandomHash"),
+            InventoryPktField(hash="NotfoundHashRandom"),
+        ]
+    )
+    with open("samples/notfound.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # getblocks
+    pkt = BitcoinHdr() / BitcoinGetblocks(
+        version=70001, hashes=["xxx", "yyyy"], hash_stop="",
+    )
+    with open("samples/getblocks.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # getheaders
+    pkt = BitcoinHdr() / BitcoinGetheaders(version=70001, hashes=[], hash_stop="")
+    with open("samples/getheaders.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # tx
+    pkt = BitcoinHdr() / BitcoinTx(
+        version=70001,
+        tx_in_count=4,
+        tx_in=[TxInPktField(), TxInPktField(), TxInPktField(), TxInPktField()],
+        tx_out_count=2,
+        tx_out=[TxOutPktField(), TxOutPktField()],
+    )
+    with open("samples/tx.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # block
+    pkt = BitcoinHdr() / BitcoinBlock(
+        version=70001, bits=40, txns=[BitcoinTx(), BitcoinTx(), BitcoinTx()]
+    )
+    with open("samples/block.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # headers
+    pkt = BitcoinHdr() / BitcoinHeaders(
+        headers=[
+            BlockHeaderPktField(),
+            BlockHeaderPktField(),
+            BlockHeaderPktField(),
+            BlockHeaderPktField(),
+            BlockHeaderPktField(),
+            BlockHeaderPktField(),
+        ]
+    )
+    with open("samples/headers.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # ping
+    pkt = BitcoinHdr() / BitcoinPing()
+    with open("samples/ping.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # pong
+    pkt = BitcoinHdr() / BitcoinPong()
+    with open("samples/pong.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # reject
+    pkt = BitcoinHdr() / BitcoinReject(
+        message=VarStrPktField(data="It's a message about reject"),
+        reason=VarStrPktField(data="Reason of reject"),
+    )
+    with open("samples/reject.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # filterload
+    pkt = BitcoinHdr() / BitcoinFilterload(filter=VarStrPktField(data="xxserrsfggt"))
+    with open("samples/filterload.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # filteradd
+    pkt = BitcoinHdr() / BitcoinFilteradd(filter=VarStrPktField(data="qwerty"))
+    with open("samples/filteradd.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # merkleblock
+    pkt = BitcoinHdr() / BitcoinMerkleblock(
+        hashes=["hash1", "hash2", "hash"], flags=[1, 2, 3, 4]
+    )
+    with open("samples/merkleblock.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # feefilter
+    pkt = BitcoinHdr() / BitcoinFeefilter(feerate=10)
+    with open("samples/feefilter.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # sendcmpct
+    pkt = BitcoinHdr() / BitcoinSendcmpct()
+    with open("samples/sendcmpct.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # cmpctblock
+    pkt = BitcoinHdr() / BitcoinCmpctblock(
+        shortids=[12, 11, 77, 45],
+        prefilled_txn=[PrefilledTxn(), PrefilledTxn(), PrefilledTxn()],
+    )
+    with open("samples/cmpctblock.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # getblocktxn
+    pkt = BitcoinHdr() / BitcoinGetblocktxn(
+        block_hash="blockhash", indexes=[15, 22, 225]
+    )
+    with open("samples/getblocktxn.bin", "wb") as myFile:
+        myFile.write(raw(pkt))
+
+    # blocktxn
+    pkt = BitcoinHdr() / BitcoinBlocktxn(
+        transactions=[BitcoinTx(), BitcoinTx(), BitcoinTx(), BitcoinTx()]
+    )
+    with open("samples/blocktxn.bin", "wb") as myFile:
+        myFile.write(raw(pkt))


### PR DESCRIPTION
**Modifications**
* Version message has `addr_recv` field before version `106` as well. 
* Version message typo for relay field
* Typo: inventroy typo corrected to inventory
* VarInt from count_of is working now
* Updated the readme, telling that the script is working only with python 2.x
* Typo: `header` command to `headers`
* Fix: The filters were updated to match the protocol
* Feature: Added missing messages for version `70001` and up
* Updated documentation to match the implemented methods
* Added example script

**All modifications are based on https://bitcoin.org/en/developer-reference#p2p-network**